### PR TITLE
Skip oversized attachments in migrate-images

### DIFF
--- a/netlify/functions/migrate-images.mts
+++ b/netlify/functions/migrate-images.mts
@@ -8,10 +8,12 @@ const TARGET_FIELD = "Cloudinary_Image"
 const CLOUDINARY_FOLDER = "petes-act-images"
 
 const MAX_RECORDS_PER_RUN = 8
+const CLOUDINARY_MAX_IMAGE_BYTES = 10 * 1024 * 1024
 
 interface AirtableAttachment {
   url: string
   filename?: string
+  size?: number
 }
 
 interface AirtableRecord {
@@ -111,8 +113,18 @@ export default async (req: Request): Promise<void> => {
   for (const record of batch) {
     const attachments = record.fields[SOURCE_FIELD]
     if (!isAttachmentArray(attachments)) continue
+    const source = attachments[0]
+    if (
+      typeof source.size === "number" &&
+      source.size > CLOUDINARY_MAX_IMAGE_BYTES
+    ) {
+      console.warn(
+        `migrate-images: skipping ${record.id} (${source.filename ?? "image"}): ${source.size} bytes exceeds Cloudinary ${CLOUDINARY_MAX_IMAGE_BYTES} limit`
+      )
+      continue
+    }
     try {
-      const url = await uploadToCloudinary(attachments[0].url)
+      const url = await uploadToCloudinary(source.url)
       await writeBack(token, record.id, url)
       migrated++
       console.log(`migrate-images: migrated ${record.id} -> ${url}`)


### PR DESCRIPTION
## Problem
Two calendar events (both 2026-07-31) share a source image `7.31-Pete's-5x7.png` at **20,430,821 bytes (~19.5 MB)**. Cloudinary's Free plan rejects any source image over **10 MB** (`image_max_size_bytes`), so the scheduled `migrate-images` function hit `400 File size too large` on these records **every run** — catching, logging, and retrying them indefinitely.

## Fix
Check the Airtable attachment's `size` (already returned in attachment metadata) before attempting the upload. If it exceeds Cloudinary's 10 MB cap, `console.warn` with the record id / filename / size and skip — instead of firing a request that always 400s.

Why a guard rather than an incoming transformation: the 10 MB limit is enforced on the **source** file *before* any transformation runs, so a resize can't rescue an oversized original on the Free plan. Detecting and skipping is the correct behavior.

## Notes
- Does **not** migrate the 2 stuck records — that PNG still needs to be resized under 10 MB in Airtable. This just stops the repeated errors and makes the reason clear in logs.
- No regression when `size` is absent: falls through to the existing try/catch.
- Typecheck clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)